### PR TITLE
Add pathnameOnly prop to only send page views when the pathname changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Google Analytics component for React Router. Bear in mind this is a super simple
 |------|------|-------------|---------------|
 | `id` | string | Google Analytics tracking ID | Required |
 | `debug` | boolean | If enabled, react-router-ga will log all page views to the console | `false` |
+| `pathnameOnly` | boolean | If enabled, react-router-ga will only send page views when the pathname changed | `false` |
 
 ## Usage Example
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ import type { Location, RouterHistory } from 'react-router-dom';
 type Props = {
   id: string, // Google Analytics Tracking ID
   debug: boolean,
+  pathnameOnly: boolean,
   children?: React.Node,
   location: Location,
   history: RouterHistory
@@ -48,6 +49,13 @@ class ReactRouterGA extends React.Component<Props> {
     if (!window.ga) {
       return;
     }
+
+    // Do nothing if pathnameOnly is enabled and the pathname didn't change.
+    if (this.props.pathnameOnly && location.pathname === this.lastPathname) {
+      return;
+    }
+
+    this.lastPathname = location.pathname;
 
     // Sets the page value on the tracker.
     window.ga('set', 'page', location.pathname);

--- a/lib/index.js
+++ b/lib/index.js
@@ -68,6 +68,13 @@ var ReactRouterGA = function (_React$Component) {
         return;
       }
 
+      // Do nothing if pathnameOnly is enabled and the pathname didn't change.
+      if (this.props.pathnameOnly && location.pathname === this.lastPathname) {
+        return;
+      }
+
+      this.lastPathname = location.pathname;
+
       // Sets the page value on the tracker.
       window.ga('set', 'page', location.pathname);
 


### PR DESCRIPTION
I have a use case where I only want to send page views when the pathname changed. If the search or any other properties of the location object changed, then don't send a page view.

This use case can be enabled using the `pathnameOnly` prop. I've implemented this prop, added docs to the readme, and tested it manually in my own project.

Thanks for providing this library and for considering my PR.