### PR TITLE
Add basename prop 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Google Analytics component for React Router. Bear in mind this is a super simple
 | Prop | Type | Description | Default value |
 |------|------|-------------|---------------|
 | `id` | string | Google Analytics tracking ID | Required |
+| `basename` | string | If provided, react-router-ga will prepend the basename to the pathname of each page view. (This should match the `basename` provided to the React Router `BrowserRouter` component. See [here](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/api/BrowserRouter.md#basename-string) for documentation.)
 | `debug` | boolean | If enabled, react-router-ga will log all page views to the console | `false` |
 | `trackPathnameOnly` | boolean | If enabled, react-router-ga will only send page views when the pathname changed | `false` |
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ import type { Location, RouterHistory } from 'react-router-dom';
 
 type Props = {
   id: string, // Google Analytics Tracking ID
+  basename: string,
   debug: boolean,
   trackPathnameOnly: boolean,
   children?: React.Node,
@@ -57,15 +58,16 @@ class ReactRouterGA extends React.Component<Props> {
 
     this.lastPathname = location.pathname;
 
-    // Sets the page value on the tracker.
-    window.ga('set', 'page', location.pathname);
+    // Sets the page value on the tracker. If a basename is provided, then it is prepended to the pathname.
+    const page = this.props.basename ? `${this.props.basename}${location.pathname}` : location.pathname;
+    window.ga('set', 'page', page);
 
     // Sending the pageview no longer requires passing the page
     // value since it's now stored on the tracker object.
     window.ga('send', 'pageview');
 
     if (this.props.debug) {
-      console.info(`[react-router-ga] Page view: ${location.pathname}`);
+      console.info(`[react-router-ga] Page view: ${page}`);
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ class ReactRouterGA extends React.Component<Props> {
 
     // Sets the page value on the tracker. If a basename is provided, then it is prepended to the pathname.
     const page = this.props.basename ? `${this.props.basename}${location.pathname}` : location.pathname;
+    
     window.ga('set', 'page', page);
 
     // Sending the pageview no longer requires passing the page

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,15 +75,16 @@ var ReactRouterGA = function (_React$Component) {
 
       this.lastPathname = location.pathname;
 
-      // Sets the page value on the tracker.
-      window.ga('set', 'page', location.pathname);
+      // Sets the page value on the tracker. If a basename is provided, then it is prepended to the pathname.
+      var page = this.props.basename ? '' + this.props.basename + location.pathname : location.pathname;
+      window.ga('set', 'page', page);
 
       // Sending the pageview no longer requires passing the page
       // value since it's now stored on the tracker object.
       window.ga('send', 'pageview');
 
       if (this.props.debug) {
-        console.info('[react-router-ga] Page view: ' + location.pathname);
+        console.info('[react-router-ga] Page view: ' + page);
       }
     }
   }, {

--- a/lib/index.js
+++ b/lib/index.js
@@ -77,6 +77,7 @@ var ReactRouterGA = function (_React$Component) {
 
       // Sets the page value on the tracker. If a basename is provided, then it is prepended to the pathname.
       var page = this.props.basename ? '' + this.props.basename + location.pathname : location.pathname;
+
       window.ga('set', 'page', page);
 
       // Sending the pageview no longer requires passing the page


### PR DESCRIPTION
I have a use case where I am using React Router `BrowserRouter` with a `basename` prop. (The `basename` prop is used when an app is served from a sub-directory of your server. See [here](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/api/BrowserRouter.md#basename-string) for docs.)

This PR adds an optional `basename` prop to the `Analytics` component. If the value of this prop is truthy, then react-router-ga will prepend it to the pathname before sending each page view.
