### PR TITLE
Add map option for logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Google Analytics component for React Router. Bear in mind this is a super simple
 | `basename` | string | If provided, react-router-ga will prepend the basename to the pathname of each page view. (This should match the `basename` provided to the React Router `BrowserRouter` component. See [here](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/api/BrowserRouter.md#basename-string) for documentation.) | - |
 | `debug` | boolean | If enabled, react-router-ga will log all page views to the console | `false` |
 | `trackPathnameOnly` | boolean | If enabled, react-router-ga will only send page views when the pathname changed | `false` |
+| `map` | function | If provided, react-router-ga will run this function on the pathname of each page view before logging. At most one of `basename` and `map` should be set. |
 
 ## Usage Example
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ type Props = {
   basename: string,
   debug: boolean,
   trackPathnameOnly: boolean,
+  map?: (a: string) => string,
   children?: React.Node,
   location: Location,
   history: RouterHistory
@@ -63,7 +64,12 @@ class ReactRouterGA extends React.Component<Props> {
     this.lastPathname = location.pathname;
 
     // Sets the page value on the tracker. If a basename is provided, then it is prepended to the pathname.
-    const page = this.props.basename ? `${this.props.basename}${location.pathname}` : location.pathname;
+    var page = location.pathname;
+    if (this.props.basename) {
+      page = `${this.props.basename}${location.pathname}`;
+    } else if (this.props.map) {
+      page = this.props.map(page)
+    }
 
     window.ga('set', 'page', page);
 
@@ -82,7 +88,8 @@ class ReactRouterGA extends React.Component<Props> {
 }
 
 ReactRouterGA.defaultProps = {
-  debug: false
+  debug: false,
+  trackPathnameOnly: false
 };
 
 export default withRouter(ReactRouterGA);


### PR DESCRIPTION
Add an ability to run an arbitrary function on the path name before logging it to GA. This is a generalization of `basename` and is useful when one wishes to e.g. redact sensitive components of URLs.